### PR TITLE
Fix GPG Keys line, so CentOS 7.x yum update works on c1 servers

### DIFF
--- a/7.4.1708/overlay-armv7l/etc/yum.repos.d/CentOS-Base.repo
+++ b/7.4.1708/overlay-armv7l/etc/yum.repos.d/CentOS-Base.repo
@@ -4,7 +4,7 @@ mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo
 baseurl=http://mirror.centos.org/altarch/$releasever/os/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32
 
 #released updates
 [updates]
@@ -13,7 +13,7 @@ mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo
 baseurl=http://mirror.centos.org/altarch/$releasever/updates/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32
 
 #additional packages that may be useful
 [extras]
@@ -22,5 +22,5 @@ mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo
 baseurl=http://mirror.centos.org/altarch/$releasever/extras/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32
 


### PR DESCRIPTION
This fixes #22.  Tested on a newly created c1 server in Paris just now.